### PR TITLE
Fix CI permissions issue (#72)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -88,6 +88,10 @@ jobs:
           NEO4J_USER: neo4j
           NEO4J_PASSWORD: StrongPass123
 
+      - name: Change ownership of workspace
+        if: always()
+        run: sudo chown -R runner:docker .
+
       - name: Get Postgres logs
         if: always()
         run: docker logs ${{ job.services.postgres.id }}


### PR DESCRIPTION
The GitHub Actions workflow was failing with a permissions error when trying to remove the tests/sample_data directory during post-job cleanup. This was caused by the Docker volume mount changing the ownership of the directory.

This change adds a step to the workflow to change the ownership of the workspace back to the runner user after the tests have run. This allows the cleanup step to succeed.