### PR TITLE
fix(ci): Add health check to PostgreSQL service in CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,6 +24,7 @@ jobs:
           - 5433:5432
         volumes:
           - ./tests/sample_data/init.sql:/docker-entrypoint-initdb.d/init.sql
+        options: --health-cmd="pg_isready -U testuser -d testdb" --health-interval=5s --health-timeout=5s --health-retries=10
       neo4j:
         image: neo4j:latest
         env:


### PR DESCRIPTION
The GitHub Actions workflow was failing because the tests were trying to connect to the PostgreSQL database before it was ready to accept connections. This resulted in a "no response" error and caused the workflow to hang.

This change adds a health check to the PostgreSQL service definition in the `.github/workflows/python-test.yml` file. The health check uses the `pg_isready` command to ensure that the database is fully initialized and ready to accept connections before the rest of the job proceeds. This is a standard practice for service containers in GitHub Actions and is already used by the Neo4j service in the same workflow.