### PR TITLE
Fix: a duplicate `options` key in the GitHub workflow file

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,11 +22,6 @@ jobs:
           POSTGRES_DB: testdb
         ports:
           - 5433:5432
-        options: >-
-          --health-cmd "pg_isready -U testuser"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
         volumes:
           - ./tests/sample_data/init.sql:/docker-entrypoint-initdb.d/init.sql
         options: --health-cmd="pg_isready -U testuser -d testdb" --health-interval=5s --health-timeout=5s --health-retries=10


### PR DESCRIPTION
The GitHub workflow file `.github/workflows/python-test.yml` was failing due to a duplicate `options` key under the `postgres` service. This change removes the duplicate key, resolving the syntax error.