### PR TITLE
Fix: Remove redundant options from postgres service in workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,7 +24,6 @@ jobs:
           - 5433:5432
         volumes:
           - ./tests/sample_data/init.sql:/docker-entrypoint-initdb.d/init.sql
-        options: --health-cmd="pg_isready -U testuser -d testdb" --health-interval=5s --health-timeout=5s --health-retries=10
       neo4j:
         image: neo4j:latest
         env:


### PR DESCRIPTION
The GitHub Actions workflow was failing due to an error in the postgres service definition. The 'options' key, used for a health check, was causing a parsing error. This key is also redundant, as a later step in the workflow already performs a health check for the postgres service.

This change removes the 'options' key to fix the workflow error.