### PR TITLE
Fix(ci): Correct step order for PostgreSQL initialization

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -39,10 +39,11 @@ jobs:
         options: --health-cmd "wget -O /dev/null --server-response --timeout=2 http://neo4j:7474 2>&1 | awk '/^  HTTP/{print $2}' | grep -q 200" --health-interval 5s --health-timeout 5s --health-retries 10
 
     steps:
-      - name: Clean workspace and set owner
-        run: sudo chown -R runner:docker .
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Clean workspace and set owner
+        run: sudo chown -R runner:docker .
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v3


### PR DESCRIPTION
The GitHub Actions workflow failed to initialize the PostgreSQL service container. This was caused by an incorrect ordering of the `checkout` and `chown` steps.

The `chown` command was executing on a directory before the code was checked out, leading to incorrect permissions on the repository files. This likely prevented the Docker service from mounting the `init.sql` file into the container, causing the initialization to fail.

This commit reorders the steps to ensure that file ownership is changed *after* the code has been checked out, resolving the container startup issue. Local tests now pass with this configuration.