### PR TITLE
fix(ci): Correct postgres volume mount in GHA workflow (#87)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 5433:5432
         volumes:
-          - ./tests/sample_data/init.sql:/docker-entrypoint-initdb.d/init.sql
+          - ./tests/sample_data:/docker-entrypoint-initdb.d
         options: --health-cmd "pg_isready -U testuser -d testdb" --health-interval 5s --health-timeout 5s --health-retries 10
       neo4j:
         image: neo4j:latest


### PR DESCRIPTION
The postgres container was failing to initialize in the GitHub Actions workflow due to an incorrect volume mount. The workflow was attempting to mount a single file, which caused Docker to create a directory instead.

This change corrects the volume mount to mount the directory containing the init script, as expected by the postgres Docker image.